### PR TITLE
Analysis Request View error when the page redirects the user

### DIFF
--- a/bika/health/browser/analysisrequest/view.py
+++ b/bika/health/browser/analysisrequest/view.py
@@ -12,10 +12,7 @@ from email.mime.text import MIMEText
 
 class AnalysisRequestView(AnalysisRequestViewView):
 
-    def __call__(self):
-
-        super(AnalysisRequestView, self).__call__()
-
+    def after_call(self):
         if "email_popup_submit" in self.request:
             self.sendAlertEmail()
 
@@ -24,8 +21,7 @@ class AnalysisRequestView(AnalysisRequestViewView):
                         'indicate an imminent life-threatening condition.')
             self.addMessage(message, 'warning')
 
-        self.renderMessages()
-        return self.template()
+        return True
 
     def isPanicAlertAutopopupEnabled(self):
         if "email_popup_submit" in self.request:

--- a/bika/health/browser/analysisrequest/view.py
+++ b/bika/health/browser/analysisrequest/view.py
@@ -12,7 +12,10 @@ from email.mime.text import MIMEText
 
 class AnalysisRequestView(AnalysisRequestViewView):
 
-    def after_call(self):
+    def __call__(self):
+
+        result = super(AnalysisRequestView, self).__call__()
+
         if "email_popup_submit" in self.request:
             self.sendAlertEmail()
 
@@ -20,8 +23,10 @@ class AnalysisRequestView(AnalysisRequestViewView):
             message = _('Some results exceeded the panic levels that may '
                         'indicate an imminent life-threatening condition.')
             self.addMessage(message, 'warning')
-
-        return True
+        if result is None:
+            return
+        self.renderMessages()
+        return self.template()
 
     def isPanicAlertAutopopupEnabled(self):
         if "email_popup_submit" in self.request:


### PR DESCRIPTION
Related to https://github.com/senaite/bika.lims/pull/473

## Description of the issue/feature this PR addresses

AnalysisRequestViewView `__call__` method returns html code (string) or `None` depending on whether there is a http redirection.

## Current behavior before PR

If there is a redirection, father class returns `None` and children classes crash because they are trying to render the page calling `self.template()` while nothing has been set up.

## Desired behavior after PR is merged

Check father `__call__` returned value. if it is `None`, return None and don't call `self.template()`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html