### PR TITLE
Using parameter "vocabulary" wasn't working in bika_setup

### DIFF
--- a/bika/health/content/bikasetup.py
+++ b/bika/health/content/bikasetup.py
@@ -69,7 +69,8 @@ class BikaSetupSchemaExtender(object):
                               "Patient's 'Publication preferences' tab."))
         ),
         ExtLinesField('PatientPublicationPreferences',
-            vocabulary='bika.lims.vocabularies.CustomPubPrefVocabularyFactory',
+            vocabulary_factory='bika.lims.vocabularies'
+                        '.CustomPubPrefVocabularyFactory',
             schemata = 'Results Reports',
             widget = MultiSelectionWidget(
                 label = _("Default publication preference for Patients"),

--- a/bika/health/content/patient.py
+++ b/bika/health/content/patient.py
@@ -432,7 +432,7 @@ schema = Person.schema.copy() + Schema((
                           "to the Patient automatically."))
     ),
     LinesField('PublicationPreferences',
-        vocabulary='bika.lims.vocabularies.CustomPubPrefVocabularyFactory',
+        vocabulary_factory='bika.lims.vocabularies.CustomPubPrefVocabularyFactory',
         schemata='Publication preference',
         widget=MultiSelectionWidget(
             label=_("Publication preference"),


### PR DESCRIPTION
 Since the function/class returns a VocabularyFactory, it should be introduced as a "vocabulary_factory" parameter.